### PR TITLE
remove ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "testing"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0",
     "rsvp": "^3.0.17",
     "sauce-connect-launcher": "^0.11.1",
     "saucie": "^0.1.1"


### PR DESCRIPTION
I don't believe this is actually used in this addon.