### PR TITLE
Add device orientation to `ember sauce` options

### DIFF
--- a/lib/commands/sauce.js
+++ b/lib/commands/sauce.js
@@ -27,6 +27,9 @@ module.exports = {
       name: 'platform', type: String, aliases: ['p']
     },
     {
+      name: 'orientation', type: String, aliases: ['o']
+    },
+    {
       name: 'launcher-name', type: String
     },
     {
@@ -93,7 +96,8 @@ module.exports = {
         options.browser,
         options.visibility,
         options.version,
-        options.platform
+        options.platform,
+        options.orientation
       ].filter(function(n) { return !!n; }).join('_').replace(/(\s|\.)+/g, "_");
     }
 
@@ -113,6 +117,10 @@ module.exports = {
     if (options.platform) {
       args.push('-p');
       args.push(options.platform);
+    }
+    if(options.orientation) {
+      args.push('-do');
+      args.push(options.orientation);
     }
 
     if (options.protocol === 'browser') {


### PR DESCRIPTION
`-o` or `--orientation` now works for `ember sauce` and goes into the name as well.
This feature is necessary for any mobile device testing.

Option matches to the saucie `-do` option, see https://github.com/johanneswuerbach/saucie/blob/master/lib/argv.js#L39