### PR TITLE
Export individual Qunit failure details

### DIFF
--- a/tests/acceptance/export-test-results-test.js
+++ b/tests/acceptance/export-test-results-test.js
@@ -18,6 +18,8 @@ test('registers the test export', function(assert) {
 
   andThen(function() {
     assert.strictEqual(window.global_test_results, null);
-    assert.notEqual(window.QUnit.config.callbacks.done.indexOf(window.exportTestResultsForSauce), -1);
+    assert.ok(window.QUnit.config.callbacks.done.some(function(fn) {
+      return fn.name === 'exportTestResultsForSauce';
+    }));
   });
 });

--- a/vendor/export-test-results.js
+++ b/vendor/export-test-results.js
@@ -1,14 +1,53 @@
 /* global QUnit, after */
-window.global_test_results = null;
+(function() {
+  window.global_test_results = null;
 
-if (typeof QUnit !== 'undefined') {
-  window.exportTestResultsForSauce = function (testResults) {
-    window.global_test_results = testResults;
-  };
-  QUnit.done(window.exportTestResultsForSauce);
-} else if (typeof Mocha !== 'undefined') {
-  after(function() {
-    window.global_test_results = window.mochaRunner.stats;
-    window.global_test_results.reports = [];
-  });
-}
+  if (typeof QUnit !== 'undefined') {
+    var log = [];
+    // Custom data is limited to 64KB. Leave some padding for the other test
+    // result data.
+    // https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-CustomData
+    var SIZE_LIMIT = 63800;
+    var limitReached = false;
+
+    function checkSize(newLog) {
+      return JSON.stringify(newLog).length > SIZE_LIMIT;
+    }
+
+    function exportTestResultsForSauce(testResults) {
+      testResults.tests = log;
+      window.global_test_results = testResults;
+    }
+
+    // Used for testing
+    exportTestResultsForSauce.name = 'exportTestResultsForSauce';
+
+    QUnit.done(exportTestResultsForSauce);
+
+    QUnit.log(function(details) {
+      if (!limitReached && details.result === false) {
+        var failure = {
+          result: details.result,
+          expected: details.expected,
+          actual: details.actual,
+          message: details.message,
+          source: details.source,
+          name: details.module + ': ' + details.name
+        };
+
+        var newLog = log.concat([failure]);
+        if (checkSize(newLog)) {
+          limitReached = true;
+        } else {
+          log = newLog;
+        }
+      }
+    });
+
+  } else if (typeof Mocha !== 'undefined') {
+    after(function() {
+      window.global_test_results = window.mochaRunner.stats;
+      window.global_test_results.reports = [];
+    });
+  }
+})();


### PR DESCRIPTION
Log the details of each failed test and send them to SauceLabs along with the other test result info.

Limit to first 15 failures because of a SauceLabs bug.

Fixes #53 